### PR TITLE
Use Masonry waterfall for the projects page (match photography)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "hexo-renderer-less": "4.0.0",
         "hexo-renderer-marked": "^7.0.1",
         "hexo-tag-photozoom": "^1.0.3",
+        "image-size": "^2.0.2",
         "lunr": "^2.3.9",
         "node-waves": "^0.7.6"
       },
@@ -4905,15 +4906,15 @@
       }
     },
     "node_modules/image-size": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
-      "optional": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
       "bin": {
         "image-size": "bin/image-size.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=16.x"
       }
     },
     "node_modules/immutable": {
@@ -5656,6 +5657,19 @@
         "mime": "^1.4.1",
         "needle": "^3.1.0",
         "source-map": "~0.6.0"
+      }
+    },
+    "node_modules/less/node_modules/image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/less/node_modules/mime": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "hexo-renderer-less": "4.0.0",
     "hexo-renderer-marked": "^7.0.1",
     "hexo-tag-photozoom": "^1.0.3",
+    "image-size": "^2.0.2",
     "lunr": "^2.3.9",
     "node-waves": "^0.7.6"
   },

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { imageSize } = require('image-size');
 
 let pageview = { visitor_count: 0, pv_map: {} };
 try {
@@ -38,6 +39,29 @@ hexo.extend.helper.register('flickr_photos', () => {
     console.warn('flickr_photos.json not found or invalid; photography grid will be empty.');
     return [];
   }
+});
+
+// Intrinsic dimensions of a local /projects card image, returned as a CSS
+// `aspect-ratio` value ("640 / 480") so the card can reserve the image's height
+// before it loads — letting the client-side Masonry on /projects lay out on the
+// first paint with no reflow (the same height-reservation the photography grid
+// already gets from Flickr's width/height). Read once per file and cached (the
+// images are static build inputs). Degrades to '' on a missing/unreadable file
+// so the card simply gets no reservation rather than the build failing.
+const PROJECT_IMG_DIR = path.join(__dirname, '../source/img/projects');
+const aspectCache = new Map();
+hexo.extend.helper.register('project_image_aspect', (name, ext) => {
+  const file = name + (ext || '.jpg');
+  if (aspectCache.has(file)) return aspectCache.get(file);
+  let ratio = '';
+  try {
+    const { width, height } = imageSize(fs.readFileSync(path.join(PROJECT_IMG_DIR, file)));
+    if (width && height) ratio = `${width} / ${height}`;
+  } catch (e) {
+    console.warn(`project image ${file} not found or unreadable; card will have no aspect-ratio.`);
+  }
+  aspectCache.set(file, ratio);
+  return ratio;
 });
 
 /**

--- a/themes/ssarcandy/js/ProjectTags.js
+++ b/themes/ssarcandy/js/ProjectTags.js
@@ -1,17 +1,16 @@
+/* global Masonry, imagesLoaded */
 import lunr from 'lunr';
 import { highlightActiveTag } from './Helper';
 
 const VISIBLE_CLASS = 'on';
-// Single source of truth for the column-count breakpoint (mirrors projectlist.less).
-const MOBILE_QUERY = window.matchMedia('(max-width: 760px)');
 
 const $input = document.getElementById('plugin-search-input');
 const index = lunr.Index.load(window.SEARCH_INDEX);
 
 // Stable, original-order snapshot of the project cards. Captured ONCE, before the
-// masonry below reshuffles the DOM, so a lunr ref (an index into site.data.projects)
-// keeps mapping to cards[ref]. getElementsByClassName is live + document-order, so it
-// must be frozen to an array before any node moves.
+// masonry below reorders the DOM, so a lunr ref (an index into site.data.projects)
+// keeps mapping to cards[ref]. getElementsByClassName is live + document-order, so
+// it must be frozen to an array before any node moves.
 const cards = [...document.getElementsByClassName('plugin')];
 
 // In-feed ads sit outside the .plugin filter set (the lunr index maps to .plugin by
@@ -23,39 +22,35 @@ const ads = [...document.getElementsByClassName('project-ad-item')];
 
 const tagFromHash = () => decodeURIComponent(location.hash.slice(1));
 
-function createDiv(className) {
-  const node = document.createElement('div');
-  node.className = className;
-  return node;
-}
-
-// Masonry scaffold: a flex row of columns, plus an off-screen attic that holds
-// whatever isn't currently placed (filtered-out cards, unused ads) so stale nodes
-// don't linger in the layout.
-const masonry = createDiv('project-masonry');
-const attic = createDiv('project-attic');
+// Off-screen attic holding whatever isn't currently placed (filtered-out cards,
+// unused ads) so stale nodes don't linger in the masonry layout.
+const attic = document.createElement('div');
 attic.style.display = 'none';
-projectList.append(masonry, attic);
+projectList.parentNode.appendChild(attic);
 
-let columns = [];
+// Masonry over the rendered cards. Each card reserves its image height via the
+// build-time aspect-ratio (project-item.ejs) and its text is already in the DOM,
+// so the grid lays out correctly on the first paint — the same approach the
+// photography grid uses. Built below once the libraries are ready.
+let masonry = null;
 
-function ensureColumns(count) {
-  if (columns.length === count) return;
-  masonry.textContent = '';
-  columns = Array.from({ length: count }, () => {
-    const col = createDiv('project-column');
-    masonry.appendChild(col);
-    return col;
-  });
+function relayout() {
+  if (masonry) masonry.layout();
 }
 
-// Lay out the visible cards. They're streamed in source order (ads spliced in after
-// every AD_EVERY-th card) and dealt round-robin across the columns, so reading
-// row-by-row follows source order (1 2 / 3 4 / …) while each column still packs as a
-// tight waterfall.
-function render() {
-  ensureColumns(MOBILE_QUERY.matches ? 1 : 2);
+// Re-run the layout once an in-feed ad fills and changes height, so the cards
+// around it reflow to its final size instead of leaving a gap.
+let adObserver = null;
+function observeAd(adNode) {
+  if (typeof ResizeObserver === 'undefined') return;
+  if (!adObserver) adObserver = new ResizeObserver(() => relayout());
+  adObserver.observe(adNode);
+}
 
+// Lay out the visible cards in source order — ads spliced in after every
+// AD_EVERY-th card — then re-run masonry so it packs them as a tight waterfall.
+// Anything filtered out is parked in the attic so it leaves the layout cleanly.
+function render() {
   const visible = cards.filter((card) => card.classList.contains(VISIBLE_CLASS));
   const adQuota = AD_EVERY ? Math.min(Math.floor(visible.length / AD_EVERY), ads.length) : 0;
 
@@ -63,21 +58,23 @@ function render() {
   let adsPlaced = 0;
   visible.forEach((card, i) => {
     stream.push(card);
-    if (adsPlaced < adQuota && (i + 1) % AD_EVERY === 0) {
-      stream.push(ads[adsPlaced++]);
-    }
+    if (adsPlaced < adQuota && (i + 1) % AD_EVERY === 0) stream.push(ads[adsPlaced++]);
   });
-  stream.forEach((node, i) => columns[i % columns.length].appendChild(node));
 
-  // Park whatever wasn't placed so it leaves the layout cleanly.
-  cards.forEach((card) => {
-    if (!card.classList.contains(VISIBLE_CLASS)) attic.appendChild(card);
-  });
+  // Re-append in the new order (the .grid-sizer stays put as the first child),
+  // then park whatever wasn't placed.
+  stream.forEach((node) => projectList.appendChild(node));
+  cards.forEach((card) => { if (!card.classList.contains(VISIBLE_CLASS)) attic.appendChild(card); });
   ads.slice(adsPlaced).forEach((ad) => attic.appendChild(ad));
+
+  if (masonry) {
+    masonry.reloadItems();
+    masonry.layout();
+  }
 }
 
-// Show the cards matching `query` (a lunr search term or a tag); an empty query shows
-// all. Then re-lay out the columns.
+// Show the cards matching `query` (a lunr search term or a tag); an empty query
+// shows all. Then re-lay out the grid.
 function applyFilter(query) {
   const term = query.trim();
   const matches = term ? new Set(index.search(term).map((hit) => Number(hit.ref))) : null;
@@ -111,6 +108,22 @@ document.addEventListener('click', (e) => {
 
 $input.addEventListener('input', () => applyFilter($input.value));
 window.addEventListener('hashchange', hashchange);
-MOBILE_QUERY.addEventListener('change', render); // re-deal when the column count flips
+window.addEventListener('resize', relayout); // re-pack when the column width flips
 
+// Build the grid, lay out the initial (hash-driven) filter, then watch the ads.
+masonry = new Masonry(projectList, {
+  itemSelector: '.project-list-item',
+  columnWidth: '.project-grid-sizer',
+  percentPosition: true,
+  gutter: 20,
+  transitionDuration: 0,
+});
 hashchange();
+ads.forEach(observeAd);
+
+// Safety nets for heights that settle after the first paint and would otherwise
+// leave the masonry overlapping: images decoding (any card lacking a reserved
+// aspect-ratio) and the self-hosted Roboto webfont swapping in, which can change
+// the description text's height. Both just trigger a relayout.
+imagesLoaded(projectList).on('progress', relayout);
+if (document.fonts && document.fonts.ready) document.fonts.ready.then(relayout);

--- a/themes/ssarcandy/layout/_partial/projects/project-item.ejs
+++ b/themes/ssarcandy/layout/_partial/projects/project-item.ejs
@@ -1,5 +1,10 @@
+<%
+// Reserve the image's height before it loads (build-time intrinsic ratio) so the
+// client-side Masonry grid lays out with no reflow, mirroring the photography card.
+var __aspect = project_image_aspect(project.name, project.img_ext);
+%>
 <article class="article project-item" itemprop="blogPost">
-    <img src="<%- url_for('img/projects/' + project.name + (project.img_ext || '.jpg')) %>" alt='<%- project.description.replace(/"/g, "") %>' class="preview photozoom" data-action="zoom">
+    <img src="<%- url_for('img/projects/' + project.name + (project.img_ext || '.jpg')) %>" alt='<%- project.description.replace(/"/g, "") %>' class="preview photozoom" data-action="zoom"<% if (__aspect) { %> style="aspect-ratio: <%= __aspect %>;"<% } %>>
 
     <div class="project-item-details">
         <%- partial('./project-title') %>

--- a/themes/ssarcandy/layout/projects.ejs
+++ b/themes/ssarcandy/layout/projects.ejs
@@ -9,6 +9,7 @@ var __n = 0;
 %>
 <ul class="post-list project-list"<% if (__every) { %> data-ad-every="<%= __every %>"<% } %>>
   <input type="search" id="plugin-search-input" placeholder="Search">
+  <li class="project-grid-sizer"></li>
 
   <% for (i in site.data.projects) { %>
     <li class="project-list-item plugin on">
@@ -28,4 +29,6 @@ var __n = 0;
 window.SEARCH_INDEX = <%- lunr_index(site.data.projects) %>;
 </script>
 
+<script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
+<script src="https://unpkg.com/imagesloaded@5/imagesloaded.pkgd.min.js"></script>
 <script src="<%- url_for('js/projectPage.bundle.js') %>" type="module"></script>

--- a/themes/ssarcandy/source/css/_partial/projectlist.less
+++ b/themes/ssarcandy/source/css/_partial/projectlist.less
@@ -2,23 +2,30 @@
     display: none;
 }
 
-/* ---------- Projects: horizontal-order waterfall (JS masonry) ----------
-   CSS multi-column fills *vertically* (1 4 7 / 2 5 8 …). To read in source
-   order across rows (1 2 / 3 4 / …) while still packing each column tightly,
-   ProjectTags.js builds the `.project-masonry` flex row below and distributes
-   cards round-robin (card i → column i % N). Pre-JS fallback: cards stack in a
-   single column as direct children of `.project-list`.
-   Card images keep their natural aspect ratio, so column heights pack
-   organically (and may shift as images load). */
-.project-masonry {
-    display: flex;
-    gap: 20px;
-    align-items: flex-start; /* let columns size to their own content */
+/* ---------- Projects: Masonry waterfall ----------
+   ProjectTags.js runs Masonry over these cards (itemSelector `.project-list-item`,
+   columnWidth `.project-grid-sizer`), the same library the photography grid uses —
+   but on project-specific class names, NOT photography's `.grid-item` (whose
+   opacity:0 reveal and overflow:hidden would hide these cards and clip the
+   click-to-zoom). Each card reserves its image height via a build-time
+   `aspect-ratio` (project-item.ejs) and its text is server-rendered, so the grid
+   packs correctly on the first paint. Two columns above 760px, one below; pre-JS
+   the floated cards still flow two-up before Masonry takes over. */
+.project-list .project-grid-sizer,
+.project-list .project-list-item {
+    width: calc(50% - 10px); /* 2 columns with a 20px gutter (Masonry gutter: 20) */
 }
 
-.project-column {
-    flex: 1 1 0;
-    min-width: 0; /* allow columns to shrink below content's intrinsic width */
+.project-list .project-list-item {
+    float: left;
+}
+
+@media screen and (max-width:760px) {
+    .project-list .project-grid-sizer,
+    .project-list .project-list-item {
+        width: 100%;
+        float: none;
+    }
 }
 
 .project-list-item {


### PR DESCRIPTION
The projects grid used a hand-rolled flex/round-robin "waterfall" that
only alternated cards between two columns, so column heights never
balanced. Replace it with the same Masonry library the photography grid
uses, so cards pack as a true shortest-column waterfall while still
reading in source order across rows.

To lay out on the first paint with no reflow, reserve each card's image
height the way the photography card does: a new build-time helper
(project_image_aspect) reads the local image's intrinsic dimensions via
image-size and emits a CSS aspect-ratio on the card image. The card text
is already server-rendered, so its height is known to Masonry at run
time; a document.fonts.ready relayout covers the Roboto webfont swap, and
imagesLoaded covers any image lacking a reserved ratio — mirroring the
photography grid's safety nets.

Masonry runs on project-specific class names (.project-list-item /
.project-grid-sizer), NOT photography's .grid-item, whose opacity:0
reveal and overflow:hidden would have hidden these cards and clipped the
click-to-zoom. Tag filtering, client search, proportional in-feed ad
interleaving, and the 2-col/1-col breakpoint are all preserved.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012X5UPvfQZcgZ8xsR571SMe