### PR TITLE
SEO improvements: meta correctness + landing-page previews & descriptions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,9 @@ title: SSARCandy's Blog
 subtitle: ''
 description: Nothing special, just a blog for a nerdy software engineer. I write about programming, trashtalk, and other things that interest me.
 timezone: Asia/Taipei
-language: en
+# Content is Traditional Chinese (Taiwan). Drives <html lang> and og:locale
+# (zh-TW -> zh_TW), so the page's language is consistent for search engines.
+language: zh-TW
 
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
@@ -15,6 +17,11 @@ url: https://ssarcandy.tw
 root: /
 permalink: :year/:month/:day/:title/
 permalink_defaults:
+# Drop the trailing "index.html" from generated URLs (og:url, canonical, internal
+# links) so each page has one clean canonical form instead of both /foo/ and
+# /foo/index.html.
+pretty_urls:
+  trailing_index: false
 
 # Directory
 source_dir: source

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://ssarcandy.tw/sitemap.xml

--- a/themes/ssarcandy/layout/_partial/head.ejs
+++ b/themes/ssarcandy/layout/_partial/head.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="<%= config.language %>">
 <head>
   <meta charset="utf-8">
   <%
@@ -38,13 +38,12 @@
    }
   %>
   <meta name="keywords" content="<%= keyWords %>">
+  <link rel="canonical" href="<%= full_url_for(page.path) %>">
   <%- open_graph({ image: page_images(page, [theme.avatar]) }) %>
-  
+
   <% if (theme.rss){ %>
     <link rel="alternative" href="<%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">
   <% } %>
-  <meta name="summary" content="<%=(strip_html(page.excerpt) || config.description)%>">
-  <meta name="Description" content="<%=config.description%>">
   <%- favicon_tag(theme.favicon) %>
   <%- css('css/style') %>
   <% if (theme.adsense.enable) { %>

--- a/themes/ssarcandy/layout/post.ejs
+++ b/themes/ssarcandy/layout/post.ejs
@@ -18,26 +18,28 @@
     </div>
 </article>
 
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "Article",
-  "mainEntityOfPage": "<%- post.permalink %>",
-  "headline": "<%- post.title %>",
-  "datePublished": "<%- new Date(post.date) %>",
-  "dateModified": "<%- new Date(post.date) %>",
-  "author": "SSARCandy",
-  "image": {
-    "@type": "ImageObject",
-    "url": "https://ssarcandy.tw<%- post.image %>"
-  },
-  "publisher":{ 
-    "@type" : "Organization",
-    "name": "SSARCandy's Blog",
-    "logo": {
-      "@type": "ImageObject",
-      "url": "https://ssarcandy.tw/img/logo.png"
-    }
-  }     
-}
-</script>
+<%
+// Build the structured data as an object and JSON.stringify it, so dates are valid
+// ISO 8601, the title/description can't break JSON quoting, and the image is a real
+// URL (first content image, falling back to the site logo) rather than the bare
+// domain. https://schema.org/Article
+var __ldImg = (page_images(post, []) || [])[0] || theme.avatar || '/img/logo.png';
+var __ldImgUrl = /^https?:\/\//.test(__ldImg) ? __ldImg : full_url_for(__ldImg);
+var __ld = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  mainEntityOfPage: post.permalink,
+  headline: post.title,
+  description: strip_html(post.excerpt || post.content || '').replace(/\s+/g, ' ').trim().substring(0, 200),
+  datePublished: new Date(post.date).toISOString(),
+  dateModified: new Date(post.updated || post.date).toISOString(),
+  author: { '@type': 'Person', name: 'SSARCandy' },
+  image: { '@type': 'ImageObject', url: __ldImgUrl },
+  publisher: {
+    '@type': 'Organization',
+    name: config.title,
+    logo: { '@type': 'ImageObject', url: full_url_for('/img/logo.png') }
+  }
+};
+%>
+<script type="application/ld+json"><%- JSON.stringify(__ld) %></script>


### PR DESCRIPTION
SEO improvements, verified against the rendered `public/` output. Two commits.

## Commit 1 — meta correctness (audit items 1–5)

**1. Language consistency** (`_config.yml`, `head.ejs`)
Content is Traditional Chinese but the page sent three conflicting signals (`<html lang="zh">`, config `language: en`, `og:locale="en_US"`). Set `language: zh-TW` and drive `<html lang>` from it → `<html lang="zh-TW">` + `og:locale="zh_TW"`.

**2. Structured data** (`post.ejs`)
Article JSON-LD was partly invalid: raw JS-`Date` strings → **ISO 8601**; `image.url` was the bare domain → **first content image** (logo fallback) as a real `ImageObject`; string author → `Person`. Rebuilt via `JSON.stringify` (quoting-safe).

**3. Canonical / `og:url`** (`head.ejs`, `_config.yml`)
Added `<link rel="canonical">` and `pretty_urls.trailing_index: false`, so `og:url`/canonical are the clean `/foo/` URL, not a mix of `/foo/` and `/foo/index.html`.

**4. Deduplicate description meta** (`head.ejs`)
Dropped site-wide `name="Description"` + non-standard `name="summary"`; the `open_graph` helper already emits a per-page `name="description"`.

**5. robots.txt** (`source/robots.txt`)
Added, allowing all crawlers + pointing to the sitemap.

## Commit 2 — landing-page previews & descriptions

**Preview images** (`head.ejs`): `/projects` and `/photography` had no body, so they fell back to the **logo** for `og:image`. Now they surface real content — an explicit `og_image` front-matter wins, else the first non-GIF project image / the first Flickr photo, with the avatar as a final fallback. Posts keep scraping their own content images.

**Per-page descriptions**: gave `/projects` and `/photography` proper, keyword-aware descriptions (front-matter). For the remaining bodyless pages, the description now falls back to that page's **header subtitle** (the same i18n intro shown in `<h5 class="subtitle">` — post/project/photography/archive) before the generic site blurb. Result:

| Page | description source |
|------|--------------------|
| Home | `post.intro` subtitle |
| Archive / Tag | `archive.intro` subtitle |
| Projects / Photography | rich front-matter description |
| About | its own body text |
| Posts | excerpt |

No page falls back to the generic "Nothing special…" site blurb anymore (verified: 0 pages).

## Verification
- `<html lang="zh-TW">`, clean canonical/`og:url`, `og:locale="zh_TW"`
- JSON-LD parses valid; ISO date, real image URL, `Person` author
- exactly one `description` meta; no leftover `Description`/`summary`
- `/projects` og:image = real project image; `/photography` = first Flickr photo (verified with a fixture; falls back to avatar when Flickr data is absent locally)
- `robots.txt` served with `Sitemap:`
- `npm run lint` passes (JS untouched)

## Note
`pretty_urls.trailing_index: false` is site-wide (strips `index.html` from all `url_for` links) — standard and GitHub-Pages-safe, but the one change beyond `<head>`. Not included: sitemap listing `image_meta.json`, image `alt` coverage, multiple `<h1>`, `summary_large_image`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)