### PR TITLE
SEO: real preview images + per-page descriptions for landing pages

### DIFF
--- a/source/photography/index.md
+++ b/source/photography/index.md
@@ -3,4 +3,5 @@ title: Photography
 layout: photography
 noDate: true
 comments: false
+description: "Photography by SSARCandy — an interactive map and gallery of travel, street, and landscape shots from Taiwan and around the world."
 ---

--- a/source/projects/index.md
+++ b/source/projects/index.md
@@ -4,6 +4,7 @@ layout: projects
 data: projects
 noDate: true
 comments: false
+description: "SSARCandy's open source projects — computer vision, graphics, iOS apps, Node.js libraries, and developer tools, with source code and demos."
 ---
 
 Here listed my open source projects.

--- a/themes/ssarcandy/layout/_partial/head.ejs
+++ b/themes/ssarcandy/layout/_partial/head.ejs
@@ -39,7 +39,43 @@
   %>
   <meta name="keywords" content="<%= keyWords %>">
   <link rel="canonical" href="<%= full_url_for(page.path) %>">
-  <%- open_graph({ image: page_images(page, [theme.avatar]) }) %>
+  <%
+    // Representative preview image(s) for og:image / twitter:image. Posts scrape
+    // their own content images (page_images). The data-driven landing pages have
+    // no inline images, so they'd fall back to the logo — instead surface real
+    // content: an explicit `og_image` front-matter wins, otherwise pick the first
+    // item from the page's data. Always end with the avatar as a final fallback.
+    var ogImgs = [];
+    if (page.og_image) {
+      ogImgs.push(page.og_image);
+    } else if (page.layout === 'projects') {
+      var projs = site.data.projects || [];
+      // Skip animated GIFs — a static frame makes the cleaner social card.
+      var rep = projs.find(function(p){ return (p.img_ext || '.jpg') !== '.gif'; }) || projs[0];
+      if (rep) ogImgs.push('/img/projects/' + rep.name + (rep.img_ext || '.jpg'));
+    } else if (page.layout === 'photography') {
+      var photos = flickr_photos();
+      if (photos.length) {
+        var f = photos[0];
+        ogImgs.push(f.url_c || ('https://live.staticflickr.com/' + f.server + '/' + f.id + '_' + f.secret + '_c.jpg'));
+      }
+    }
+    ogImgs.push(theme.avatar);
+
+    // Description fallback: a page's own description / excerpt / content first,
+    // then the header subtitle for this page type (the same intro shown in the
+    // <h5 class="subtitle">), and only then the generic site description — so the
+    // landing/list pages that have no body still get a meaningful, page-specific
+    // description instead of the catch-all site blurb.
+    var pageIntro = '';
+    if (is_home()) pageIntro = __('post.intro');
+    else if (page.layout === 'projects') pageIntro = __('project.intro');
+    else if (page.layout === 'photography') pageIntro = __('photography.intro');
+    else if (is_archive() || is_tag()) pageIntro = __('archive.intro');
+    else if (config.subtitle) pageIntro = config.subtitle;
+    var metaDesc = page.description || page.excerpt || page.content || pageIntro || config.description;
+  %>
+  <%- open_graph({ image: page_images(page, ogImgs), description: metaDesc }) %>
 
   <% if (theme.rss){ %>
     <link rel="alternative" href="<%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">


### PR DESCRIPTION
Follow-up to #144. Gives the data-driven landing pages real social previews and meaningful, page-specific descriptions. Verified against the rendered `public/` output.

## Preview images (`og:image` / `twitter:image`) — `head.ejs`
`/projects` and `/photography` have no body, so they fell back to the **logo**. Now they surface real content:
- explicit `og_image:` front-matter wins, else
- `/projects` → first **non-GIF** project image (the first project is an animated GIF — poor card), `/photography` → first (most recent) **Flickr photo**, else
- the avatar as a final fallback.

Posts are unchanged — they keep scraping their own content images.

## Per-page descriptions
- `/projects` and `/photography` get proper, keyword-aware descriptions via front-matter.
- For the remaining bodyless pages, the description now falls back to that page's **header subtitle** (the same i18n intro shown in `<h5 class="subtitle">`) before the generic site blurb:

| Page | description source |
|------|--------------------|
| Home | `post.intro` subtitle |
| Archive / Tag | `archive.intro` subtitle |
| Projects / Photography | rich front-matter description |
| About | its own body text |
| Posts | excerpt |

No page falls back to the generic "Nothing special…" site blurb anymore (verified: 0 pages).

## Verification
- `/projects` og:image = real project image; `/photography` = first Flickr photo (verified with a fixture; falls back to avatar when Flickr data is absent locally)
- home/archive/tag descriptions = their header subtitle; projects/photography = rich descriptions; about = body text
- canonical / lang / JSON-LD from #144 still intact on the merged base
- `npm run lint` passes (JS untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012X5UPvfQZcgZ8xsR571SMe)_