### PR TITLE
perf: bundle Masonry/imagesLoaded + lazy-load below-fold project cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,9 @@
         "hexo-renderer-marked": "^7.0.1",
         "hexo-tag-photozoom": "^1.0.3",
         "image-size": "^2.0.2",
+        "imagesloaded": "^5.0.0",
         "lunr": "^2.3.9",
+        "masonry-layout": "^4.2.2",
         "sharp": "^0.35.2"
       },
       "devDependencies": {
@@ -2920,6 +2922,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/desandro-matches-selector": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.2.tgz",
+      "integrity": "sha512-+1q0nXhdzg1IpIJdMKalUwvvskeKnYyEe3shPRwedNcWtnhEKT3ZxvFjzywHDeGcKViIxTCAoOYQWP1qD7VNyg==",
+      "license": "MIT"
+    },
     "node_modules/destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -3589,6 +3597,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ev-emitter": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-2.1.2.tgz",
+      "integrity": "sha512-jQ5Ql18hdCQ4qS+RCrbLfz1n+Pags27q5TwMKvZyhp5hh2UULUYZUy1keqj6k6SYsdqIYjnmz7xyyEY0V67B8Q==",
+      "license": "MIT"
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -3796,6 +3810,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fizzy-ui-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-2.0.7.tgz",
+      "integrity": "sha512-CZXDVXQ1If3/r8s0T+v+qVeMshhfcuq0rqIFgJnrtd+Bu8GmDmqMjntjUePypVtjHXKJ6V4sw9zeyox34n9aCg==",
+      "license": "MIT",
+      "dependencies": {
+        "desandro-matches-selector": "^2.0.0"
       }
     },
     "node_modules/flat-cache": {
@@ -4102,6 +4125,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/get-size": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/get-size/-/get-size-2.0.3.tgz",
+      "integrity": "sha512-lXNzT/h/dTjTxRbm9BXb+SGxxzkm97h/PCIKtlN/CBCxxmkkIVV21udumMS93MuVTDX583gqc94v3RjuHmI+2Q==",
+      "license": "MIT"
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
@@ -5493,6 +5522,15 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/imagesloaded": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-5.0.0.tgz",
+      "integrity": "sha512-/0JGSubc1MTCoDKVmonLHgbifBWHdyLkun+R/151E1c5n79hiSxcd7cB7mPXFgojYu8xnRZv7GYxzKoxW8BetQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ev-emitter": "^2.1.2"
+      }
+    },
     "node_modules/immutable": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
@@ -6744,6 +6782,16 @@
         "node": ">= 18"
       }
     },
+    "node_modules/masonry-layout": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/masonry-layout/-/masonry-layout-4.2.2.tgz",
+      "integrity": "sha512-iGtAlrpHNyxaR19CvKC3npnEcAwszXoyJiI8ARV2ePi7fmYhIud25MHK8Zx4P0LCC4d3TNO9+rFa1KoK1OEOaA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-size": "^2.0.2",
+        "outlayer": "^2.1.0"
+      }
+    },
     "node_modules/material-symbols": {
       "version": "0.45.4",
       "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.45.4.tgz",
@@ -7453,6 +7501,23 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outlayer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/outlayer/-/outlayer-2.1.1.tgz",
+      "integrity": "sha512-+GplXsCQ3VrbGujAeHEzP9SXsBmJxzn/YdDSQZL0xqBmAWBmortu2Y9Gwdp9J0bgDQ8/YNIPMoBM13nTwZfAhw==",
+      "license": "MIT",
+      "dependencies": {
+        "ev-emitter": "^1.0.0",
+        "fizzy-ui-utils": "^2.0.0",
+        "get-size": "^2.0.2"
+      }
+    },
+    "node_modules/outlayer/node_modules/ev-emitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz",
+      "integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q==",
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "hexo-renderer-marked": "^7.0.1",
     "hexo-tag-photozoom": "^1.0.3",
     "image-size": "^2.0.2",
+    "imagesloaded": "^5.0.0",
     "lunr": "^2.3.9",
+    "masonry-layout": "^4.2.2",
     "sharp": "^0.35.2"
   },
   "devDependencies": {

--- a/themes/ssarcandy/js/PhotographyGrid.js
+++ b/themes/ssarcandy/js/PhotographyGrid.js
@@ -1,4 +1,5 @@
-/* global Masonry, imagesLoaded */
+import Masonry from 'masonry-layout';
+import imagesLoaded from 'imagesloaded';
 
 // Enhances the server-rendered photo cards in #photography-grid: runs the Masonry
 // layout and re-orders the cards in place for the sort buttons, re-spacing the

--- a/themes/ssarcandy/js/ProjectTags.js
+++ b/themes/ssarcandy/js/ProjectTags.js
@@ -1,4 +1,5 @@
-/* global Masonry, imagesLoaded */
+import Masonry from 'masonry-layout';
+import imagesLoaded from 'imagesloaded';
 import { highlightActiveTag } from './Helper';
 
 const VISIBLE_CLASS = 'on';

--- a/themes/ssarcandy/layout/_partial/projects/project-item.ejs
+++ b/themes/ssarcandy/layout/_partial/projects/project-item.ejs
@@ -4,11 +4,16 @@
 var __aspect = project_image_aspect(project.name, project.img_ext);
 // Tiny inlined blurred placeholder shown until the real image decodes (blur-up).
 var __lqip = project_lqip(project.name, project.img_ext);
+// Only the first row of cards is above the fold; eager-load those (the first is
+// the LCP candidate, so flag it high priority) and lazy-load the rest so the
+// 20+ below-the-fold thumbnails don't contend for bandwidth on first paint.
+var __i = (typeof index !== 'undefined') ? index : 0;
+var __eager = __i < 4;
 %>
 <article class="article project-item" itemprop="blogPost">
     <div class="project-thumb">
         <% if (__lqip) { %><span class="project-thumb-lqip" style="background-image: url('<%= __lqip %>');"></span><% } %>
-        <img src="<%- url_for('img/projects/' + project.name + (project.img_ext || '.jpg')) %>" alt='<%- project.description.replace(/"/g, "") %>' class="preview photozoom" data-action="zoom"<% if (__aspect) { %> style="aspect-ratio: <%= __aspect %>;"<% } %> onload="this.parentNode.classList.add('loaded')">
+        <img src="<%- url_for('img/projects/' + project.name + (project.img_ext || '.jpg')) %>" alt='<%- project.description.replace(/"/g, "") %>' class="preview photozoom" data-action="zoom"<% if (__aspect) { %> style="aspect-ratio: <%= __aspect %>;"<% } %><% if (__eager) { %> decoding="async"<% if (__i === 0) { %> fetchpriority="high"<% } %><% } else { %> loading="lazy" decoding="async"<% } %> onload="this.parentNode.classList.add('loaded')">
     </div>
 
     <div class="project-item-details">

--- a/themes/ssarcandy/layout/photography.ejs
+++ b/themes/ssarcandy/layout/photography.ejs
@@ -56,6 +56,4 @@
     <div id="photography-map" style="display: none;"></div>
 </div>
 
-<script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
-<script src="https://unpkg.com/imagesloaded@5/imagesloaded.pkgd.min.js"></script>
 <script src="<%- url_for('js/photography.bundle.js') %>" type="module"></script>

--- a/themes/ssarcandy/layout/projects.ejs
+++ b/themes/ssarcandy/layout/projects.ejs
@@ -13,7 +13,8 @@ var __n = 0;
   <% for (i in site.data.projects) { %>
     <li class="project-list-item plugin on" data-tags="<%= (site.data.projects[i].tags || []).join('|') %>">
         <%- partial('_partial/projects/project-item', {
-            project: site.data.projects[i]
+            project: site.data.projects[i],
+            index: __n
         }) %>
     </li>
     <% __n++; %>
@@ -24,6 +25,4 @@ var __n = 0;
 
 </ul>
 
-<script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
-<script src="https://unpkg.com/imagesloaded@5/imagesloaded.pkgd.min.js"></script>
 <script src="<%- url_for('js/projectPage.bundle.js') %>" type="module"></script>


### PR DESCRIPTION
## What & why

Came out of a Lighthouse benchmark of the latest `develop`. Two perf changes:

### 1. Bundle Masonry + imagesLoaded (was loaded from unpkg.com)
`/projects` and `/photography` were pulling `masonry-layout@4` and `imagesloaded@5` from **unpkg.com at runtime** via `<script>` tags. That puts a third-party origin (extra DNS + TLS + download) on the critical path before the grid can lay out, and makes the page depend on unpkg's availability.

Now they're `npm` deps imported into the Vite bundles. Vite splits them into **one shared chunk (~28 KB / 8.7 KB gzip)** reused by both the `projectPage` and `photography` bundles — no duplication, same-origin, cacheable with the rest of the JS.

- `package.json`: `+ masonry-layout@^4.2.2`, `+ imagesloaded@^5.0.0`
- `ProjectTags.js` / `PhotographyGrid.js`: `/* global Masonry, imagesLoaded */` → real `import`s
- `projects.ejs` / `photography.ejs`: removed the two unpkg `<script>` tags

### 2. Lazy-load below-the-fold project thumbnails
All 21 project cards loaded their images eagerly. Now the first row (4 cards) stays eager — with the first flagged `fetchpriority="high"` as the LCP candidate — and the remaining 17 get `loading="lazy"`, so off-screen thumbnails no longer contend for bandwidth on first paint.

## Verification
- `npm run lint` passes
- `build:vite` + `build:hexo` succeed
- Headless-browser check: all 21 project cards laid out by Masonry, **0 page errors** (default-export interop confirmed)
- Project cards render with 4 eager / 17 `loading="lazy"` / 1 `fetchpriority="high"`

## Related
The MapLibre/supercluster half of the unpkg cleanup is split into a separate PR (#147). The two are independent — they touch different parts of `photography.ejs` — but both modify `package.json`/`package-lock.json`, so whichever merges second may need a trivial lockfile resolve.

## Note (separate follow-up, not in this PR)
The headline `/projects` LCP is still high because the **first card image is a 543 KB animated WebP** (`hamster-bopomofo_t9.gif.webp`, converted from a 3.9 MB GIF) — it's the LCP element and dominates regardless of the above. The real fix is a lightweight static poster thumbnail for animated projects, which belongs in the image pipeline and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)