### PR TITLE
a11y: fix WCAG AA color contrast and heading order on posts

### DIFF
--- a/themes/ssarcandy/layout/_partial/header.ejs
+++ b/themes/ssarcandy/layout/_partial/header.ejs
@@ -45,7 +45,10 @@
             <%= page.title %> 
         <% } %>
     </h1>
-    <h5 class="subtitle">
+    <%# Not a section heading — it holds the page intro/meta (and block content like
+        the archive tag list), so a heading element here breaks the h1→h5 outline
+        order (a11y). A div keeps the identical styling via the .subtitle class. %>
+    <div class="subtitle">
         <% if (page.date && !page.noDate) { %>
             <%- partial('post/head-meta') %>
         <% } else if (page.layout === 'projects') { %>
@@ -60,7 +63,7 @@
         <% } else { %>
             <%= config.subtitle %>
         <% } %>
-    </h5>
+    </div>
   </div>
   <% } else { %>
       <%- partial('about/head-meta') %>

--- a/themes/ssarcandy/source/css/_partial/article.less
+++ b/themes/ssarcandy/source/css/_partial/article.less
@@ -113,10 +113,9 @@
     p,
     li {
         a {
-            // Darkened accent so link text clears WCAG AA (4.5:1) on the near-white
-            // page — @accentColor itself is only 3.2:1. The bright accent stays on
-            // the underline + hover border for the same visual identity.
-            color: darken(@accentColor, 18%);
+            // AA-safe accent for the link text (see @accentTextColor); the bright
+            // @accentColor stays on the underline + hover border for visual identity.
+            color: @accentTextColor;
             border-bottom: 1px solid lighten(@accentColor, 32%);
             word-break: break-all;
 
@@ -517,8 +516,9 @@
 
 // hexo-tag-photozoom ships .zoom-initial-caption at #999 (2.8:1 on the page) and
 // its stylesheet is injected after ours, so override with a higher-specificity
-// selector to a grey that clears WCAG AA (4.5:1). Top-level: captions also appear
-// in the /projects and /photography card lists, not just inside .article.
+// selector. @secondaryTextColor is our standard muted-text-on-light colour and
+// already clears WCAG AA (4.7:1). Top-level: captions also appear in the /projects
+// and /photography card lists, not just inside .article.
 span.zoom-initial-caption {
-    color: #6b6b6b;
+    color: @secondaryTextColor;
 }

--- a/themes/ssarcandy/source/css/_partial/article.less
+++ b/themes/ssarcandy/source/css/_partial/article.less
@@ -113,7 +113,10 @@
     p,
     li {
         a {
-            color: @accentColor;
+            // Darkened accent so link text clears WCAG AA (4.5:1) on the near-white
+            // page — @accentColor itself is only 3.2:1. The bright accent stays on
+            // the underline + hover border for the same visual identity.
+            color: darken(@accentColor, 18%);
             border-bottom: 1px solid lighten(@accentColor, 32%);
             word-break: break-all;
 
@@ -510,4 +513,12 @@
         opacity: 0;
         .transition(.4s, cubic-bezier(0.18, 0.81, 0.3, 0.89));
     }
+}
+
+// hexo-tag-photozoom ships .zoom-initial-caption at #999 (2.8:1 on the page) and
+// its stylesheet is injected after ours, so override with a higher-specificity
+// selector to a grey that clears WCAG AA (4.5:1). Top-level: captions also appear
+// in the /projects and /photography card lists, not just inside .article.
+span.zoom-initial-caption {
+    color: #6b6b6b;
 }

--- a/themes/ssarcandy/source/css/_partial/header.less
+++ b/themes/ssarcandy/source/css/_partial/header.less
@@ -79,9 +79,9 @@
         // is a <div> (changed to fix the h1→h5 heading-order a11y violation).
         font-size: 16px;
         line-height: 24px;
-        // Lightened one step so the meta text clears WCAG AA (4.5:1) on the purple
-        // header — @lightPrimaryColor itself lands at 4.46:1.
-        color: lighten(@lightPrimaryColor, 4%);
+        // AA-safe muted text on the purple header (see @onPrimaryMutedColor);
+        // raw @lightPrimaryColor lands at 4.46:1.
+        color: @onPrimaryMutedColor;
     }
 
     // Post meta (date + views + reading time) on one row, wrapping on narrow screens.

--- a/themes/ssarcandy/source/css/_partial/header.less
+++ b/themes/ssarcandy/source/css/_partial/header.less
@@ -75,7 +75,13 @@
 
     .subtitle {
         padding-top: 6px;
-        color: @lightPrimaryColor;
+        // Pin the size the <h5> used to inherit from heading styles, now that this
+        // is a <div> (changed to fix the h1→h5 heading-order a11y violation).
+        font-size: 16px;
+        line-height: 24px;
+        // Lightened one step so the meta text clears WCAG AA (4.5:1) on the purple
+        // header — @lightPrimaryColor itself lands at 4.46:1.
+        color: lighten(@lightPrimaryColor, 4%);
     }
 
     // Post meta (date + views + reading time) on one row, wrapping on narrow screens.

--- a/themes/ssarcandy/source/css/_partial/highlight.less
+++ b/themes/ssarcandy/source/css/_partial/highlight.less
@@ -24,7 +24,9 @@
 }
 
 .line-numbers() {
-    color: @secondaryTextColor;
+    // Line numbers sit on the dark code background (@h-background), where
+    // @secondaryTextColor is only 2.9:1. This lighter grey clears WCAG AA (4.5:1).
+    color: #969696;
     font-size: 0.85em;
 }
 

--- a/themes/ssarcandy/source/css/_partial/highlight.less
+++ b/themes/ssarcandy/source/css/_partial/highlight.less
@@ -25,8 +25,8 @@
 
 .line-numbers() {
     // Line numbers sit on the dark code background (@h-background), where
-    // @secondaryTextColor is only 2.9:1. This lighter grey clears WCAG AA (4.5:1).
-    color: #969696;
+    // @secondaryTextColor is only 2.9:1 (see @codeMutedColor for the AA-safe grey).
+    color: @codeMutedColor;
     font-size: 0.85em;
 }
 

--- a/themes/ssarcandy/source/css/_partial/postlist.less
+++ b/themes/ssarcandy/source/css/_partial/postlist.less
@@ -59,9 +59,10 @@
         display: inline;
     }
     a {
-        color: @accentColor;
+        // Same accent-as-text-on-light role as in-article links — AA-safe token.
+        color: @accentTextColor;
         &:hover {
-            color: @accentColor;
+            color: @accentTextColor;
         }
     }
 }

--- a/themes/ssarcandy/source/css/_partial/variable.less
+++ b/themes/ssarcandy/source/css/_partial/variable.less
@@ -36,6 +36,15 @@
 // surfaces: white card background + the shared resting shadow used by content cards
 @cardBg: #FFFFFF;
 @cardShadow: 0 1px 2px rgba(151, 151, 151, 0.58);
+// Accessible text tokens — a base palette colour nudged so a given role clears
+// WCAG AA (4.5:1) on its specific background. Contrast is a property of fg×bg, so a
+// role that reuses a palette colour on a different surface gets its own token here
+// rather than mutating the base colour (which would dull/break its other, non-text
+// uses — borders, fills, brand accent). Use these for any *text*; keep the raw
+// palette colours for borders/backgrounds/identity.
+@accentTextColor:     darken(@accentColor, 18%);       // accent as link/text on the light page (3.2:1 → AA)
+@onPrimaryMutedColor: lighten(@lightPrimaryColor, 4%); // muted meta text on the purple header/rail (4.46:1 → AA)
+@codeMutedColor:      #969696;                          // muted text (line numbers) on the dark code bg (2.9:1 → AA)
 //layout
 @railWidth: 96px;
 @railExpandedWidth: 220px;


### PR DESCRIPTION
## What & why

Ran Lighthouse on 5 randomly-picked posts (2019/Prometheus, 2017/pytorch-windows, 2016/vim-plugin-manager, 2016/pbrt-camera, 2016/MSAuto). **SEO was already 100, best-practices 96, perf 95–97** — solid. The only thing below 100 was **accessibility (94–95)**, dragged down by two issues present on every post.

### 1. Color contrast (WCAG AA, 4.5:1)
Four element types failed. Each foreground was nudged to pass while keeping the same look:

| Element | before → after | ratio |
|---|---|---|
| Header subtitle meta | `#d1c4e9` → `lighten(@lightPrimaryColor, 4%)` = `#ddd3ef` | 4.46 → **5.1** |
| In-content links | `@accentColor` → `darken(@accentColor, 18%)` = `#bc05db` | 3.22 → **4.9** |
| Image captions | `#999` → `#6b6b6b` | 2.75 → **5.2** |
| Code line numbers | `@secondaryTextColor` → `#969696` | 2.86 → **4.7** |

- The **bright accent** is kept on the link underline + hover border, so links still read as the same pink — just a darker text fill.
- The **caption** color ships from `hexo-tag-photozoom`'s stylesheet, which is injected *after* the theme CSS, so it's overridden with a higher-specificity `span.zoom-initial-caption` rule (captions also appear in the /projects and /photography card lists, so the rule is top-level).

### 2. Heading order
The header's intro/meta block was an `<h5>` sitting directly under the page `<h1>` — an `h1 → h5` skip that fails `heading-order`. It isn't a real section heading (and in the archive view it holds block content like the tag list), so it's now a `<div class="subtitle">`. The desktop `font-size`/`line-height` the `<h5>` used to inherit are pinned on the `.subtitle` class, so it renders **pixel-identical** (verified: 16px/24px desktop, 14px/20px mobile, weight 400, margins 0 — same as before; only the color changed).

## Verification
- Re-ran Lighthouse on all 5 posts: **accessibility 100** on every one; **0 color-contrast failures** (was 4–5 per post)
- Headless screenshots confirm the header subtitle and in-content links/captions look unchanged apart from the intended darker/lighter shades
- `npm run lint` passes

## Note (follow-up, not in this PR)
The pbrt (math) post still flags `svg-img-alt` — MathJax renders inline math as `<svg role="img">` without an accessible name. It's low-weight (a11y still rounds to 100) and fixing it means configuring MathJax's output, so it's left as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012X5UPvfQZcgZ8xsR571SMe)_